### PR TITLE
Swap to functional

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 - Improved graceful errors for `fetch_ucirepo()` and `list_available_datasets()`
   when resources are not found/available. ([#3](https://github.com/coatless-rpkg/ucimlrepo/issues/3),
   thanks Prof. Ripley!)
+- Speed up `fetch_ucirepo()` for large data frames by switching to using base 
+  functionals instead of growing a vector in a loop while sorting variable roles.
+  ([#6](https://github.com/coatless-rpkg/ucimlrepo/pull/6))
   
 ## Bug fixes
 

--- a/R/fetch-ucirepo.R
+++ b/R/fetch-ucirepo.R
@@ -235,19 +235,19 @@ fetch_ucirepo <- function(name, id) {
   metadata$variables <- NULL
 
   # Organize variables into IDs, features, or targets
-  variables_by_role <- list(
-    ID = list(),
-    Feature = list(),
-    Target = list(),
-    Other = list()
-  )
-  for (variable in variables) {
-    if (!(variable$role %in% names(variables_by_role))) {
-      stop('Role must be one of "ID", "Feature", "Target", or "Other"')
-    }
-
-    variables_by_role[[variable$role]] <- c(variables_by_role[[variable$role]], trimws(variable$name))
+  # First, ensure all roles are valid
+  if (!all(sapply(variables, function(v) v$role %in% c("ID", "Feature", "Target", "Other")))) {
+    stop('Role must be one of "ID", "Feature", "Target", or "Other".')
   }
+
+  # Create the list of variables by role
+  variables_by_role <- lapply(
+    c("ID", "Feature", "Target", "Other"),
+    function(role) {
+      trimws(sapply(variables[sapply(variables, function(v) v$role == role)], `[[`, "name"))
+    }
+  )
+
 
   # Extract dataframes for each variable role
   ids_df <- if (length(variables_by_role$ID) > 0) df[ , unlist(variables_by_role$ID), drop = FALSE] else NULL

--- a/R/fetch-ucirepo.R
+++ b/R/fetch-ucirepo.R
@@ -248,6 +248,8 @@ fetch_ucirepo <- function(name, id) {
     }
   )
 
+  # Name the list elements
+  names(variables_by_role) <- c("ID", "Feature", "Target", "Other")
 
   # Extract dataframes for each variable role
   ids_df <- if (length(variables_by_role$ID) > 0) df[ , unlist(variables_by_role$ID), drop = FALSE] else NULL


### PR DESCRIPTION
When working with data sets that have more than 10 variables, the `for` loop approach really slowed down processing due to growing each sublist. So, we switched over to using a few base functionals that avoid that hiccup and everything flies by now!